### PR TITLE
Change days variable to a more consistent one

### DIFF
--- a/ScalingStartCredits/ScalingStartCredits/Patches/StartingCreditsPatch.cs
+++ b/ScalingStartCredits/ScalingStartCredits/Patches/StartingCreditsPatch.cs
@@ -30,7 +30,7 @@ namespace ScalingStartCredits.Patches
             groupCreditIncreaseIncrement = ScalingStartCreditsBase.Instance.configCreditIncrement.Value;
             playerThreshold = ScalingStartCreditsBase.Instance.configPlayerCountThreshold.Value;
             playerCount = ___playersManager.fullyLoadedPlayers.Count;
-            days = ___playersManager.daysPlayersSurvivedInARow;
+            days = ___playersManager.gameStats.daysSpent;
             bool conditionsMet = true;
 
 


### PR DESCRIPTION
As the days variable is calculated with daysPlayersSurvived**InARow** , if all players die this variable resets to 0. This makes the script to deposit additional credits again. **gameStats.daySpent** seems like better choice to check if it is day 0 or not.

This should resolve issue #1 